### PR TITLE
[#95][IMP] ammap colors and addition of border colors

### DIFF
--- a/main/local_modules/ammap/__openerp__.py
+++ b/main/local_modules/ammap/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': 'Ammap',
-    'version': '0.1',
+    'version': '0.2',
     'author': 'cgstudiomap.org',
     'maintainer': 'cgstudiomap.org',
     'license': 'AGPL-3',

--- a/main/local_modules/ammap/models/ammap_config.py
+++ b/main/local_modules/ammap/models/ammap_config.py
@@ -52,3 +52,11 @@ class AmMapConfig(models.Model):
         help=('Color of all areas which are in the map svg file, '
               'but not listed as areas in DataSet.')
     )
+
+    roll_over_outline_color = fields.Char(
+        string='Roll Over Outline Color',
+        default='#CC0000',
+        size=7,
+        help=("Color of area's outline when user rolls-over it")
+    )
+

--- a/main/local_modules/ammap/views/ammap_config_view.xml
+++ b/main/local_modules/ammap/views/ammap_config_view.xml
@@ -14,6 +14,7 @@
                         <field name="color" widget="color"/>
                         <field name="color_solid" widget="color"/>
                         <field name="unlisted_areas_color" widget="color"/>
+                        <field name="roll_over_outline_color" widget="color"/>
                     </group>
                 </form>
             </field>

--- a/main/local_modules/frontend/__openerp__.py
+++ b/main/local_modules/frontend/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': 'Frontend',
-    'version': '0.1',
+    'version': '0.2',
     'author': 'Jordi Riera',
     'maintainer': 'Jordi Riera',
     'license': 'AGPL-3',

--- a/main/local_modules/frontend/templates/homepage.xml
+++ b/main/local_modules/frontend/templates/homepage.xml
@@ -3,9 +3,11 @@
     <data>
         <record id="homepage_ammap_config" model="ammap.config">
             <field name="name">homepage</field>
-            <field name="color">#FDD5B9</field>
-            <field name="color_solid">#D96511</field>
-            <field name="unlisted_areas_color">#DCE0E0</field>
+            <field name="color">#97E9F7</field>
+            <field name="color_solid">#00C0ED</field>
+            <field name="unlisted_areas_color">#E2E2E4</field>
+            <field name="roll_over_outline_color">#FFFF00</field>
+
             <field name="description">Config of the map on the homepage.</field>
         </record>
 
@@ -48,6 +50,8 @@
                         colorSolid: "<t t-esc='ammap_config.color_solid'/>",
                         // Color for country without value.
                         unlistedAreasColor: "<t t-esc='ammap_config.unlisted_areas_color'/>",
+                        // Color of borders when rolling over a country.
+                        rollOverOutlineColor: "<t t-esc='ammap_config.roll_over_outline_color'/>",
 
                         autoZoom: false,
                         balloonText: "[[title]] ([[value]])"


### PR DESCRIPTION
* pump up the version of ammap and frontend modules
* add roll_over_border_color field to ammap_config
* update of homepage to add roll_over_border_color parameter
* update the colors to match colors set in production

fix #95 