### PR TITLE
frontend_listing: split city, state, country in listing.

### DIFF
--- a/main/local_modules/frontend_listing/controllers/listing.py
+++ b/main/local_modules/frontend_listing/controllers/listing.py
@@ -123,10 +123,12 @@ class Listing(Base):
                                 for ind in partner.industry_ids
                                 ]
                         ),
-                        'location': partner.location,
+                        'city': partner.city,
+                        'state_name': partner.state_id.name,
+                        'country_name': partner.country_id.name,
                     }
                     for partner in partners
-                    ],
+                ],
             )
 
         _logger.debug('search: %s', search)

--- a/main/local_modules/frontend_listing/static/src/js/directory.js
+++ b/main/local_modules/frontend_listing/static/src/js/directory.js
@@ -59,8 +59,18 @@ function bootstrap_table_ajax(search, status) {
                         sortable: true
                     },
                     {
-                        field: 'location',
-                        title: 'Location',
+                        field: 'city',
+                        title: 'City',
+                        sortable: true
+                    },
+                    {
+                        field: 'state_name',
+                        title: 'State',
+                        sortable: true
+                    },
+                    {
+                        field: 'country_name',
+                        title: 'Country',
                         sortable: true
                     }
                 ],


### PR DESCRIPTION
work on #541 
@M4rtine le bold se met que sur la colonne city, tu veux problablement revoir ca.

![d_20160210_001](https://cloud.githubusercontent.com/assets/547282/12966439/5c75851a-d02c-11e5-9b21-3573f2927ab2.png)

<!---
@huboard:{"order":484.0,"milestone_order":597,"custom_state":""}
-->
