### PR TITLE
718 hour res partner count visit

### DIFF
--- a/main/local_modules/res_partner_count/res_partner.py
+++ b/main/local_modules/res_partner_count/res_partner.py
@@ -33,7 +33,7 @@ class ResPartnerCountView(models.Model):
 
     active_partner_id = fields.Many2one('res.partner', string='Viewer')
     passive_partner_id = fields.Many2one('res.partner', string='Viewed')
-    datetime = fields.Datetime('Date', default=fields.Datetime.now())
+    # datetime = fields.Datetime('Date', default=fields.Datetime.now())
 
 
 class ResPartner(models.Model):
@@ -51,5 +51,5 @@ class ResPartner(models.Model):
         return counter_pool.create({
             'active_partner_id': self.id,
             'passive_partner_id': viewed_partner.id,
-            'datetime': datetime.datetime.now(),
+            # 'datetime': datetime.datetime.now(),
         })

--- a/main/local_modules/res_partner_count/res_partner.py
+++ b/main/local_modules/res_partner_count/res_partner.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 import logging
-
+import datetime
 from openerp import models, fields, api
 
 _logger = logging.getLogger(__name__)
@@ -50,5 +50,6 @@ class ResPartner(models.Model):
         counter_pool = self.env['res.partner.count.view']
         return counter_pool.create({
             'active_partner_id': self.id,
-            'passive_partner_id': viewed_partner.id
+            'passive_partner_id': viewed_partner.id,
+            'datetime': datetime.datetime.now(),
         })

--- a/main/local_modules/res_partner_count/tests/test_res_partner.py
+++ b/main/local_modules/res_partner_count/tests/test_res_partner.py
@@ -19,22 +19,9 @@
 #
 ##############################################################################
 import logging
-import datetime
 from openerp.tests import common
 
 _logger = logging.getLogger(__name__)
-
-
-class NewDatetime(datetime.datetime):
-    """Cannot mock datetime.datetime easy
-    source:
-        http://stackoverflow.com/questions/4481954/python-trying-to-mock-datetime-date-today-but-not-working  # noqa
-
-    """
-
-    @classmethod
-    def now(cls):
-        return cls(1980, 4, 5, 12, 0, 0)
 
 
 class TestResPartner(common.TransactionCase):
@@ -42,30 +29,12 @@ class TestResPartner(common.TransactionCase):
 
     def setUp(self):
         super(TestResPartner, self).setUp()
-        # pseudo mock of datetime
-        # self.__datetime will be used to restore the real datetime.datetime
-        self.__datetime = datetime.datetime
-        datetime.datetime = NewDatetime
         self.partner_pool = self.env['res.partner']
         self.partner1 = self.partner_pool.create({'name': 'partner1'})
         self.partner2 = self.partner_pool.create({'name': 'partner2'})
-
-    def tearDown(self):
-        """Restore datetime class to avoid any wrong interaction with other tests.
-
-        tearDownClass should not be used here, to avoid issue if the tests are ran
-        in multi-process.
-        """
-        datetime.datetime = self.__datetime
 
     def test_add_count_view(self):
         """Test the entry res.partner.count.view is created."""
         res = self.partner1.add_count_view(self.partner2)
         self.assertEqual(self.partner1, res.active_partner_id)
         self.assertEqual(self.partner2, res.passive_partner_id)
-
-    def test_add_count_view_datetimeToNow(self):
-        """Check when a count view is created, the datetime of the count is
-        equal to now()"""
-        count = self.partner1.add_count_view(self.partner2)
-        self.assertEqual('1980-04-05 12:00:00', count.datetime)

--- a/main/local_modules/res_partner_count/tests/test_res_partner.py
+++ b/main/local_modules/res_partner_count/tests/test_res_partner.py
@@ -19,10 +19,22 @@
 #
 ##############################################################################
 import logging
-
+import datetime
 from openerp.tests import common
 
 _logger = logging.getLogger(__name__)
+
+
+class NewDatetime(datetime.datetime):
+    """Cannot mock datetime.datetime easy
+    source:
+        http://stackoverflow.com/questions/4481954/python-trying-to-mock-datetime-date-today-but-not-working  # noqa
+
+    """
+
+    @classmethod
+    def now(cls):
+        return cls(1980, 4, 5, 12, 0, 0)
 
 
 class TestResPartner(common.TransactionCase):
@@ -30,12 +42,30 @@ class TestResPartner(common.TransactionCase):
 
     def setUp(self):
         super(TestResPartner, self).setUp()
+        # pseudo mock of datetime
+        # self.__datetime will be used to restore the real datetime.datetime
+        self.__datetime = datetime.datetime
+        datetime.datetime = NewDatetime
         self.partner_pool = self.env['res.partner']
         self.partner1 = self.partner_pool.create({'name': 'partner1'})
         self.partner2 = self.partner_pool.create({'name': 'partner2'})
+
+    def tearDown(self):
+        """Restore datetime class to avoid any wrong interaction with other tests.
+
+        tearDownClass should not be used here, to avoid issue if the tests are ran
+        in multi-process.
+        """
+        datetime.datetime = self.__datetime
 
     def test_add_count_view(self):
         """Test the entry res.partner.count.view is created."""
         res = self.partner1.add_count_view(self.partner2)
         self.assertEqual(self.partner1, res.active_partner_id)
         self.assertEqual(self.partner2, res.passive_partner_id)
+
+    def test_add_count_view_datetimeToNow(self):
+        """Check when a count view is created, the datetime of the count is
+        equal to now()"""
+        count = self.partner1.add_count_view(self.partner2)
+        self.assertEqual('1980-04-05 12:00:00', count.datetime)

--- a/main/local_modules/res_partner_count/views/res_partner_count_view.xml
+++ b/main/local_modules/res_partner_count/views/res_partner_count_view.xml
@@ -9,7 +9,7 @@
                     <sheet>
                         <field name="active_partner_id" />
                         <field name="passive_partner_id" />
-                        <field name="datetime" />
+                        <field name="create_date" />
                     </sheet>
                 </form>
             </field>
@@ -21,7 +21,7 @@
                 <tree string="Partner Count Views">
                     <field name="active_partner_id" />
                     <field name="passive_partner_id" />
-                    <field name="datetime" />
+                    <field name="create_date" />
                 </tree>
             </field>
         </record>
@@ -32,7 +32,7 @@
                 <search string="Search Relations">
                     <field name="active_partner_id" />
                     <field name="passive_partner_id" />
-                    <field name="datetime" />
+                    <field name="create_date" />
                 </search>
             </field>
         </record>


### PR DESCRIPTION
Pour éviter le bug, on enlève `res_partner_count.datetime` et on utilise `res_partner_count.create_date`.

De toute manière `datetime` aurait eut la meme valeur que `create_date`

work on #718 