### PR TITLE
mise en production

### DIFF
--- a/main/local_modules/frontend_studio/controllers/studio.py
+++ b/main/local_modules/frontend_studio/controllers/studio.py
@@ -53,7 +53,7 @@ class Studio(Base):
             'filter_domain': partner.country_id.name,
         })
         user_partner = request.env['res.users'].browse(request.uid).partner_id
-        user_partner.add_count_view(partner)
+        user_partner.add_count_view(partner, request)
         return request.website.render('frontend_studio.view', values)
 
     @statsd.timed(

--- a/main/local_modules/res_partner_count/res_partner.py
+++ b/main/local_modules/res_partner_count/res_partner.py
@@ -33,7 +33,8 @@ class ResPartnerCountView(models.Model):
 
     active_partner_id = fields.Many2one('res.partner', string='Viewer')
     passive_partner_id = fields.Many2one('res.partner', string='Viewed')
-    # datetime = fields.Datetime('Date', default=fields.Datetime.now())
+    ip = fields.Char('IP of the viewer')
+    host = fields.Char('Host the viewer used')
 
 
 class ResPartner(models.Model):
@@ -41,15 +42,17 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     @api.model
-    def add_count_view(self, viewed_partner):
+    def add_count_view(self, viewed_partner, request):
         """Add an entry res.partner.count.view.
 
         :param viewed_partner: The visited partner.
+        :param werkzeug.local.LocalStack request: request the view has been done with.
         :return: the new res.partner.count.view entry.
         """
         counter_pool = self.env['res.partner.count.view']
         return counter_pool.create({
             'active_partner_id': self.id,
             'passive_partner_id': viewed_partner.id,
-            # 'datetime': datetime.datetime.now(),
+            'ip': request.httprequest.remote_addr,
+            'host': request.httprequest.host,
         })

--- a/main/local_modules/res_partner_count/tests/test_res_partner.py
+++ b/main/local_modules/res_partner_count/tests/test_res_partner.py
@@ -19,6 +19,7 @@
 #
 ##############################################################################
 import logging
+import mock
 from openerp.tests import common
 
 _logger = logging.getLogger(__name__)
@@ -35,6 +36,11 @@ class TestResPartner(common.TransactionCase):
 
     def test_add_count_view(self):
         """Test the entry res.partner.count.view is created."""
-        res = self.partner1.add_count_view(self.partner2)
+        request = mock.MagicMock(name='mock_request')
+        request.httprequest.remote_addr = ip = '127.0.0.666'
+        request.httprequest.host = host = 'travis'
+        res = self.partner1.add_count_view(self.partner2, request)
         self.assertEqual(self.partner1, res.active_partner_id)
         self.assertEqual(self.partner2, res.passive_partner_id)
+        self.assertEqual(host, res.host)
+        self.assertEqual(ip, res.ip)

--- a/main/local_modules/res_partner_count/views/res_partner_count_view.xml
+++ b/main/local_modules/res_partner_count/views/res_partner_count_view.xml
@@ -8,6 +8,8 @@
                 <form string="Partner Count Views">
                     <sheet>
                         <field name="active_partner_id" />
+                        <field name="ip"/>
+                        <field name="host"/>
                         <field name="passive_partner_id" />
                         <field name="create_date" />
                     </sheet>
@@ -20,6 +22,8 @@
             <field name="arch" type="xml">
                 <tree string="Partner Count Views">
                     <field name="active_partner_id" />
+                    <field name="ip"/>
+                    <field name="host"/>
                     <field name="passive_partner_id" />
                     <field name="create_date" />
                 </tree>
@@ -31,6 +35,8 @@
             <field name="arch" type="xml">
                 <search string="Search Relations">
                     <field name="active_partner_id" />
+                    <field name="ip"/>
+                    <field name="host"/>
                     <field name="passive_partner_id" />
                     <field name="create_date" />
                 </search>

--- a/main/local_modules/website_iframe_host/__openerp__.py
+++ b/main/local_modules/website_iframe_host/__openerp__.py
@@ -36,6 +36,7 @@
     'data': [
         'security/ir.model.access.csv',
         'views/website_iframe_host.xml',
+        'data/website_iframe_host_data.xml',
         'templates/template_body.xml',
     ],
     'installable': True,

--- a/main/local_modules/website_iframe_host/data/website_iframe_host_data.xml
+++ b/main/local_modules/website_iframe_host/data/website_iframe_host_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!--Set so developers can work easily-->
+        <record id="localhost" model="website.iframe.host">
+            <field name="host">localhost:8069</field>
+            <field name="search_domain">[]</field>
+            <field name="hide_navbar">False</field>
+            <field name="light_hosting">False</field>
+        </record>
+        <!--Set so the website work for us :)-->
+        <record id="cgstudiomap" model="website.iframe.host">
+            <field name="host">cgstudiomap.org</field>
+            <field name="search_domain">[]</field>
+            <field name="hide_navbar">False</field>
+            <field name="light_hosting">False</field>
+        </record>
+    </data>
+</openerp>

--- a/main/local_modules/website_iframe_host/models/website.py
+++ b/main/local_modules/website_iframe_host/models/website.py
@@ -4,7 +4,7 @@ from openerp import models, fields
 class Website(models.Model):
     _inherit = 'website'
 
-    navbar = True
+    hide_navbar = False
 
 
 class WebsiteIframeHost(models.Model):
@@ -17,4 +17,11 @@ class WebsiteIframeHost(models.Model):
         'Search Domain',
         help='Domain that will be injected in searches for the given host.'
     )
-    navbar = fields.Boolean('Display navbar?', default=False)
+    hide_navbar = fields.Boolean('Hide Navbar?', default=False)
+    light_hosting = fields.Boolean(
+        'Light Hosting?', default=False,
+        help=(
+            'If checked the page like "edit studio" or "add studio" will be redirected'
+            'to cgstudiomap.org'
+        )
+    )

--- a/main/local_modules/website_iframe_host/static/config.json
+++ b/main/local_modules/website_iframe_host/static/config.json
@@ -1,3 +1,0 @@
-{
-  "whitelisted_hosts": ["cgstudiomap.org", "localhost"]
-}

--- a/main/local_modules/website_iframe_host/templates/template_body.xml
+++ b/main/local_modules/website_iframe_host/templates/template_body.xml
@@ -6,7 +6,15 @@
                   inherit_id="frontend_base.navbar"
                   name="Website Iframe Host: navbar">
             <xpath expr="//nav[@role='navigation']" position="attributes">
-                <attribute name="t-att-style">'display:none' if not display_navbar else ''</attribute>
+                <attribute name="t-att-style">'display:none' if hide_navbar else ''</attribute>
+            </xpath>
+        </template>
+        <!--change the href of the button add studio-->
+        <template id="website_iframe_host.add_studio_button"
+                  inherit_id="frontend_listing.base"
+                  name="Website Iframe Host: add studio">
+            <xpath expr="//a[@role='button']" position="attributes">
+                <attribute name="t-att-target">'_blank' if light_hosting else 'self'</attribute>
             </xpath>
         </template>
     </data>

--- a/main/local_modules/website_iframe_host/views/website_iframe_host.xml
+++ b/main/local_modules/website_iframe_host/views/website_iframe_host.xml
@@ -8,7 +8,8 @@
                     <group name="Details">
                         <field name="host"/>
                         <field name="search_domain"/>
-                        <field name="navbar"/>
+                        <field name="hide_navbar"/>
+                        <field name="light_hosting"/>
                     </group>
                 </form>
             </field>
@@ -21,13 +22,14 @@
                 <tree string="Website Iframe Hosts">
                     <field name="host"/>
                     <field name="search_domain"/>
-                    <field name="navbar"/>
+                    <field name="hide_navbar"/>
+                    <field name="light_hosting"/>
                 </tree>
             </field>
         </record>
 
         <record id="action_website_iframe_host" model="ir.actions.act_window">
-            <field name="name">Website Iframe Host listing</field>
+            <field name="name">Website Iframe Hosts</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">website.iframe.host</field>
             <field name="view_type">form</field>


### PR DESCRIPTION
- res_partner_count: add host and ip to the visit
- website_iframe_host: simplification of the condition of authorization

simplification. No white list. Only data in the database. if the host is
not in the database, it is not allowed.
- website_iframe_host: add localhost and cgstudiomap as hosts
- website_iframe_host: fix issue with navbar and add light_hosting
- with the previous logic, the navbar was hidden by default, while we
  wanted the opposite. It would have oblige us to manage all the pages.
  Now the navbar is on by default, so the pages should not be affected.
- light_hosting tags a host in a way it won't host pages require login
  (add studio, edit studio mainly targeted here)
