### PR TITLE
website_iframe_host: revision of implementation of get_host_from_session

### DIFF
--- a/main/local_modules/website_iframe_host/controllers/base.py
+++ b/main/local_modules/website_iframe_host/controllers/base.py
@@ -82,11 +82,12 @@ def get_host_from_session(session_id):
                 'referrer': referrer,
                 'request_host': request_host,
                 'host': host,
+                'iframe_host': str(iframe_host),
                 'iframe_host.host': iframe_host.host
             }
         )
     )
-    return host
+    return iframe_host
 
 
 def get_iframe_host():

--- a/main/local_modules/website_iframe_host/controllers/base.py
+++ b/main/local_modules/website_iframe_host/controllers/base.py
@@ -19,19 +19,6 @@ class IframeHostError(FrontendBaseError):
         super(IframeHostError, self).__init__(message)
 
 
-class NotAuthorizedHostFrontendBaseError(FrontendBaseError):
-    """Exception that should be raised if the host name is not authorized to
-    display the iframe.
-    """
-
-    def __init__(self, host_name):
-        super(NotAuthorizedHostFrontendBaseError, self).__init__(
-            'The host "{host_name}" is not authorized to display the iframe.'.format(
-                host_name=host_name
-            )
-        )
-
-
 class NotCompatibleSearchDomainFrontendBaseError(IframeHostError):
     """Exception that should be raised when the search domain from website.iframe.host
     is not compatible and cannot be turned into list/tuple.

--- a/main/local_modules/website_iframe_host/tests/test_website_iframe_host.py
+++ b/main/local_modules/website_iframe_host/tests/test_website_iframe_host.py
@@ -1,7 +1,7 @@
 import functools
 import mock
-import unittest
 
+from openerp.tests import common
 import time
 from openerp.addons.website_iframe_host.controllers.base import get_host_from_session
 
@@ -12,14 +12,21 @@ def get_module_path(module_name):
     )
 
 
-class TestGetHostFromSessions(unittest.TestCase):
+class TestGetHostFromSessions(common.TransactionCase):
     """Test suite for the get_host_from_session function."""
-    module_request_path = get_module_path('request')
-    mock_patch_request = functools.partial(mock.patch, module_request_path)
 
     def setUp(self):
+        super(TestGetHostFromSessions, self).setUp()
         self.func = get_host_from_session
-        self.host = 'cgstudiomap.org'
+        self.website_iframe_host_pool = self.env['website.iframe.host']
+
+        self.module_request_path = get_module_path('request')
+        self.mock_patch_request = functools.partial(mock.patch, self.module_request_path)
+
+        self.hostname = 'cgstudiomap.org'
+        self.host = self.website_iframe_host_pool.create(
+            {'host': self.hostname, 'search_domain': []}
+        )
         self.referrers = (
             # regular
             'http://www.cgstudiomap.org',
@@ -43,92 +50,106 @@ class TestGetHostFromSessions(unittest.TestCase):
             'motion.cafe.cgstudiomap.org',
         )
 
-    @mock_patch_request()
-    def test_whenTheFunctionIsCalledForTheFirstTime_referrerIsReturned(self,
-                                                                       mock_request):
+    def test_whenTheFunctionIsCalledForTheFirstTime_referrerIsReturned(self):
         """Test the behaviour with single run against the function."""
-        for referrer in self.referrers:
+        with self.mock_patch_request() as mock_request:
+            mock_request.env = self.env
+            for referrer in self.referrers:
+                mock_request.httprequest.referrer = referrer
+                ret = self.func(time.time())
+                self.assertEqual(
+                    self.host.host, ret,
+                    msg=(
+                        'The hostname was not extracted as expected from referrer {}: '
+                        'expected: {}, returned {}'.format(
+                            referrer, self.host.host, ret
+                        )
+                    )
+                )
+
+    def test_whenReferrerDoesNotExists_httprequestHostIsReturned(self):
+        """Test that host is a back up plan for getting the hostname."""
+        with self.mock_patch_request() as mock_request:
+            mock_request.env = self.env
+            mock_request.httprequest.referrer = ''
+            for hostname in self.hosts:
+                mock_request.httprequest.host = hostname
+                ret = self.func(time.time())
+                self.assertEqual(
+                    self.host.host, ret,
+                    msg=(
+                        'The hostname was not extracted as expected from host {}: '
+                        'expected: {}, returned {}'.format(
+                            hostname, self.host.host, ret
+                        )
+                    )
+                )
+
+    def test_whenCalledSeveralTimesWithDifferentSessionID_requestValuesAreUsed(self):
+        """Test that the cache does not work if the session id change"""
+        with self.mock_patch_request() as mock_request:
+            mock_request.env = self.env
+            referrer = self.referrers[0]
             mock_request.httprequest.referrer = referrer
             ret = self.func(time.time())
             self.assertEqual(
-                self.host, ret,
-                msg=(
-                    'The hostname was not extracted as expected from referrer {}: '
-                    'expected: {}, returned {}'.format(
-                        referrer, self.host, ret
-                    )
-                )
+                self.host.host, ret, msg='Return should be {}, not {}'.format(self.host.host, ret)
             )
+            referrer = 'http://example.com'
+            expected = 'example.com'
 
-    @mock_patch_request()
-    def test_whenReferrerDoesNotExists_httprequestHostIsReturned(self, mock_request):
-        """Test that host is a back up plan for getting the hostname."""
-        mock_request.httprequest.referrer = ''
-        for hostname in self.hosts:
-            mock_request.httprequest.host = hostname
+            host_example = self.website_iframe_host_pool.create(
+                {'host': expected, 'search_domain': []}
+            )
+            mock_request.httprequest.referrer = referrer
             ret = self.func(time.time())
             self.assertEqual(
-                self.host, ret,
-                msg=(
-                    'The hostname was not extracted as expected from host {}: '
-                    'expected: {}, returned {}'.format(
-                        hostname, self.host, ret
-                    )
-                )
+                host_example.host, ret, msg='Return should be {}, not {}'.format(expected, ret)
             )
 
-    @mock_patch_request()
-    def test_whenCalledSeveralTimesWithDifferentSessionID_requestValuesAreUsed(self, mock_request):  # noqa
-        """Test that the cache does not work if the session id change"""
-        referrer = self.referrers[0]
-        mock_request.httprequest.referrer = referrer
-        ret = self.func(time.time())
-        self.assertEqual(
-            self.host, ret, msg='Return should be {}, not {}'.format(self.host, ret)
-        )
-        referrer = 'http://example.com'
-        expected = 'example.com'
-        mock_request.httprequest.referrer = referrer
-        ret = self.func(time.time())
-        self.assertEqual(
-            expected, ret, msg='Return should be {}, not {}'.format(expected, ret)
-        )
-
-    @mock_patch_request()
-    def test_whenCalledSeveralTimesWithSameSessionID_cachedValueUsed(self, mock_request):
+    def test_whenCalledSeveralTimesWithSameSessionID_cachedValueUsed(self):
         """Test that the cache value is used if same session request host several times.
         """
-        referrer = self.referrers[0]
-        session_id = time.time()
-        mock_request.httprequest.referrer = referrer
-        ret = self.func(session_id)
-        self.assertEqual(
-            self.host, ret, msg='Return should be {}, not {}'.format(self.host, ret)
-        )
-        referrer = 'http://example.com'
-        mock_request.httprequest.referrer = referrer
-        ret = self.func(session_id)
-        self.assertEqual(
-            self.host, ret, msg='Return should be {}, not {}'.format(self.host, ret)
-        )
+        with self.mock_patch_request() as mock_request:
+            mock_request.env = self.env
+            referrer = self.referrers[0]
+            session_id = time.time()
+            mock_request.httprequest.referrer = referrer
+            ret = self.func(session_id)
+            self.assertEqual(
+                self.host.host, ret, msg='Return should be {}, not {}'.format(self.host.host, ret)
+            )
+            referrer = 'http://example.com'
+            mock_request.httprequest.referrer = referrer
+            ret = self.func(session_id)
+            self.assertEqual(
+                self.host.host, ret,
+                msg='Return should be {}, not {}'.format(self.host.host, ret)
+            )
 
-    @mock_patch_request()
-    def test_whenGoogleIsReferrer_cgstudiomapIsReturned(self, mock_request):
-        """We want to allow google to be the referrer for some call.
+    def test_whenUnknownReferrer_fallbackToCgstudiomap(self):
+        """We want to allow google or facebook to be the referrer for some call.
 
         For some reason, we have 500 pages because of google is referrer.
         We do not really have figured out when the case appears but for now we
         set up a fallback for the case so the 500 disappear.
+        Actually the issue can also happen when the referrer is another than google.
+        It seems the issue comes when some referrer to us directly.
 
         See: https://github.com/cgstudiomap/cgstudiomap/issues/766
         """
-        google_referrers = (
-            'http://www.google.ca', 'https://www.google.de'
-        )
-        mock_request.httprequest.host = self.host
-        for referrer in google_referrers:
-            mock_request.httprequest.referrer = referrer
-            ret = self.func(time.time())
-            self.assertEqual(
-                self.host, ret, msg='Return should be {}, not {}'.format(self.host, ret)
-        )
+        with self.mock_patch_request() as mock_request:
+            mock_request.env = self.env
+            google_referrers = (
+                'http://www.google.ca',
+                'https://www.google.de',
+                'http://www.facebook.com'
+            )
+            mock_request.httprequest.host = self.hostname
+            for referrer in google_referrers:
+                mock_request.httprequest.referrer = referrer
+                ret = self.func(time.time())
+                self.assertEqual(
+                    self.host.host, ret,
+                    msg='Return should be {}, not {}'.format(self.host.host, ret)
+            )


### PR DESCRIPTION
Was returning the name of the host before, now return the
website.iframe.host instance directly.
Because of that get_iframe_host has been simplified but kept the cache
workflow in place.

work on #766 