### PR TITLE
MEP fix auto complete

### DIFF
--- a/main/local_modules/frontend_searchbar/controllers/ajax.py
+++ b/main/local_modules/frontend_searchbar/controllers/ajax.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 TERM_CASE_PATTERN = "{field} ilike '%{term}%'"
 
-PARTNER_CONDITION = "is_company is True AND state = 'open'"
+PARTNER_CONDITION = "is_company is True AND state = 'open' AND active is True"
 #: In the case of countries, we want to list only the countries that have partner related to it.
 COUNTRY_CASE = (
     'SELECT DISTINCT res_country.name as value FROM res_partner'
@@ -94,7 +94,7 @@ class Ajax(Website):
     @statsd.timed('odoo.frontend.ajax.get_auto_complete_search_values',
                   tags=['frontend', 'frontend:search_bar', 'ajax'])
     @http.route('/ajax/search_bar/get_auto_complete_search_values',
-                type='http', methods=['GET'])
+                type='http', methods=['POST'])
     def get_auto_complete_search_values(self, term=None):
         """Ajax call to get the value for the auto-complete of the search bar.
 

--- a/main/local_modules/frontend_searchbar/static/src/css/frontend_searchbar.css
+++ b/main/local_modules/frontend_searchbar/static/src/css/frontend_searchbar.css
@@ -1,5 +1,6 @@
 #autocomplete {
     border: 0;
+    width: 100%;
 }
 
 #eac-container-autocomplete {
@@ -17,4 +18,7 @@
 
 #eac-container-autocomplete > ul > li > div > b {
     color: #b05ae2;
+}
+.easy-autocomplete {
+    width: 100% !important;
 }

--- a/main/local_modules/frontend_searchbar/templates/template_body.xml
+++ b/main/local_modules/frontend_searchbar/templates/template_body.xml
@@ -7,9 +7,6 @@
                   href="/frontend_searchbar/static/src/js/EasyAutocomplete-1.3.5/easy-autocomplete.css"/>
             <link rel="stylesheet"
                   type="text/css"
-                  href="/frontend_searchbar/static/src/js/EasyAutocomplete-1.3.5/easy-autocomplete.themes.css"/>
-            <link rel="stylesheet"
-                  type="text/css"
                   href="/frontend_searchbar/static/src/css/frontend_searchbar.css"/>
             <li class="header-search searchfield">
                 <form action="/"
@@ -18,14 +15,11 @@
                       class="navbar-form">
                     <div class="form-group" style="display:inline;">
                         <div class="input-group">
-                            <!--63 is the beta tester group-->
-                            <!--Only beta testers has access to autocomplete for now-->
-                            <!--see: https://github.com/cgstudiomap/cgstudiomap/pull/842-->
                             <input type="text"
                                    name="search"
                                    class="search-query form-control"
                                    placeholder="Search in CG Studio Map..."
-                                   t-att-id="'autocomplete' if 63 in (g.id for g in user_id.groups_id) else ''"
+                                   id="autocomplete"
                                    t-att-value="search"/>
                             <input type="hidden" name='company_status'
                                    t-att-value='company_status'/>
@@ -43,11 +37,18 @@
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                 <span class="fontCGSMicons">menu</span>
             </button>
-            <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-            <script src="/frontend_searchbar/static/src/js/EasyAutocomplete-1.3.5/jquery.easy-autocomplete.js"
-                    async="async"></script>
-            <script type="text/javascript"
-                    src="/frontend_searchbar/static/src/js/searchbar-ajax.js" async="async"></script>
+        </template>
+
+        <!--Require the load of all the JS need to autocomplete. They will be embed in a min js-->
+        <template id="frontend_searchbar.js" name="Searchbar Frontend: JS" inherit_id="frontend_base.js">
+            <xpath expr="." position="inside">
+                <script src="https://code.jquery.com/jquery-1.12.4.js" type="text/javascript"></script>
+                <script src="/frontend_searchbar/static/src/js/EasyAutocomplete-1.3.5/jquery.easy-autocomplete.js"
+                        ></script>
+                <script type="text/javascript"
+                        src="/frontend_searchbar/static/src/js/searchbar-ajax.js" ></script>
+
+            </xpath>
         </template>
 
         <template id="frontend_searchbar.geolocation" name="SearchBar: geolocation widget">

--- a/main/local_modules/shared_web_theme/static/src/css/_main.scss
+++ b/main/local_modules/shared_web_theme/static/src/css/_main.scss
@@ -91,6 +91,9 @@ body {
 
 .navbar-toggle {
 	font-size: 28px !important;
+	position: absolute !important;
+	top: 4px;
+	right: 0;
 }
 .navbar .navbar-collapse {
     text-align: left;

--- a/main/local_modules/shared_web_theme/static/src/css/base.css
+++ b/main/local_modules/shared_web_theme/static/src/css/base.css
@@ -7012,7 +7012,10 @@ body {
   margin-left: 0.2em !important; }
 
 .navbar-toggle {
-  font-size: 28px !important; }
+  font-size: 28px !important;
+  position: absolute !important;
+  top: 4px;
+  right: 0; }
 
 .navbar .navbar-collapse {
   text-align: left; }


### PR DESCRIPTION
* frontend_searchbar: excluded inactive studios.

* delete-useless-sources

* delete-useles-external-lib

* correct-css-div

without themes we must correct manually

* mobileMenu-scss-minor-correction

SCSS a compilé !!!

* fix-placeholder-hidden

* frontend_searchbar: get_auto_complete_search_values as POST

* frontend_search: display the feature to everyone

* frontend_search: load js using the min feature.